### PR TITLE
Set max KSP version compatibility to 1.7 in the NetKAN file

### DIFF
--- a/RealPlume-StockConfigs.netkan
+++ b/RealPlume-StockConfigs.netkan
@@ -2,7 +2,7 @@
     "spec_version"      : "v1.4",
     "$kref"             : "#/ckan/github/KSP-RO/RealPlume-StockConfigs",
     "ksp_version_min"   : "1.4",
-    "ksp_version_max"   : "1.6.99",
+    "ksp_version_max"   : "1.7",
     "name"              : "Real Plume - Stock Configs",
     "identifier"        : "RealPlume-StockConfigs",
     "abstract"          : "A set of effects and basic configs that can be attached to any engine as appropriate.  Requires secondary configs to function correctly.",


### PR DESCRIPTION
Hey!

As [one user mentioned on the forum thread](https://forum.kerbalspaceprogram.com/index.php?/topic/130576-161-realplume-stock-v131-11419-better-late-than-never-update/&do=findComment&comment=3642308) and one pointed out in our (CKAN's) Discord channel, these configs are only marked as compatible for KSP up to 1.6.99. The main mod instead is [already marked as compatible with KSP 1.7](https://github.com/KSP-RO/RealPlume/blob/master/RealPlume.netkan).

I assume this is an oversight, as I couldn't find anything that states an incompatibility. However I definitely might have overlooked something.

In this PR I adjust the `ksp_version_max` field to `1.7`, to match the main mod, which allows this module to be installed for all the versions of KSP falling in that range via CKAN.

If this isn't the case, and the configs are indeed **not yet** compatible with KSP 1.7, feel free to either close this PR, or let it stay open until the mod is updated.

Thanks a bunch!