### PR TITLE
New RAPIER plumes for ReStock and stock

### DIFF
--- a/GameData/RealPlume-Stock/ReStock/RAPIER.cfg
+++ b/GameData/RealPlume-Stock/ReStock/RAPIER.cfg
@@ -1,40 +1,85 @@
 @PART[RAPIER]:NEEDS[ReStock]:AFTER[ReStock]
 {
-  !EFFECTS {}
+	!EFFECTS {}
 }
 @PART[RAPIER]:NEEDS[zRealPlume,SmokeScreen,ReStock] // CR-7 R.A.P.I.E.R. Engine
 {
-    PLUME
-    {
-        name = Turbojet
-        transformName = thrustTransform
-        localRotation = 0,0,0
-        localPosition = 0,0,-0.4
-        fixedScale = 0.7
-        energy = 0.8
-        speed = 1
-        emissionMult = 1.0
-    }
-    PLUME
-    {
-        name = Hypergolic-Lower
-        transformName = thrustTransform
-        localRotation = 0,0,0
-        plumePosition = 0,0,0
-        flarePosition = 0,0,0.3
-        plumeScale = 0.4
-        flareScale = 0.4
-        energy = 1
-        speed = 1
-        emissionMult = 1.0
-    }
-    @MODULE[ModuleEngines*],0
-    {
-        %powerEffectName = Turbojet
-        %spoolEffectName = Turbojet-Spool
-    }
-    @MODULE[ModuleEngines*],1
-    {
-        %powerEffectName = Hypergolic-Lower
-    }
+	PLUME
+	{
+		name = Methalox_AirBreathingMode
+		transformName = thrustTransform
+		localRotation = 0,0,0
+		localPosition = 0,0,0
+		fixedScale = 1
+		energy = 1
+		speed = 1
+		emissionMult = 0.7
+		alphaMult = 1
+		saturationMult = 1
+		flarePosition = 0,0,-0.24
+		flareScale = 0.07
+		plumePosition = 0,0,-0.05
+		plumeScale = 0.52
+		fumePosition = 0,0,0.3
+		fumeScale = 1.5
+		blazePosition = 0,0,3.75
+		blazeScale = 0.52
+		bypassTransformName = partTransform
+		bypassRotation = 90,0,0
+		bypassPosition = 0,-0.7,0
+		bypassScale = 1
+		smokePosition = 0,0,0.2
+		smokeScale = 0.7
+	}
+	PLUME
+	{
+		name = Methalox_LowerShock
+		transformName = thrustTransform
+		localRotation = 0,0,0
+		localPosition = 0,0,0
+		fixedScale = 1
+		energy = 1
+		speed = 1
+		emissionMult = 0.7
+		alphaMult = 1
+		saturationMult = 1
+		flarePosition = 0,0,-0.24
+		flareScale = 0.07
+		plumePosition = 0,0,-0.05
+		plumeScale = 0.52
+		fumePosition = 0,0,0.3
+		fumeScale = 1.5
+		blazePosition = 0,0,3.75
+		blazeScale = 0.52
+	}
+	@MODULE[ModuleEngines*],0
+	{
+		%powerEffectName = Methalox_AirBreathingMode
+		%spoolEffectName = Methalox_AirBreathingMode-Spool
+	}
+	@MODULE[ModuleEngines*],1
+	{
+		%powerEffectName = Methalox_LowerShock
+	}
+}
+//The RAPIER has 4 smaller nozzles instead of one big nozzle, so just going by plumeScale makes it too quiet
+@PART[RAPIER]:FOR[zzRealPlume]:NEEDS[ReStock]
+{
+	@EFFECTS
+	{
+		@Methalox_AirBreathingMode
+		{
+			@AUDIO
+			{
+				@volume,1[1, ] *= 4
+			}
+		}
+		@Methalox_LowerShock
+		{
+			@AUDIO
+			{
+				@volume,1[1, ] *= 4
+			}
+		}
+	}
 }

--- a/GameData/RealPlume-Stock/Squad/RAPIER.cfg
+++ b/GameData/RealPlume-Stock/Squad/RAPIER.cfg
@@ -1,36 +1,92 @@
 @PART[RAPIER]:FOR[RealPlume]:NEEDS[SmokeScreen,!ReStock] // CR-7 R.A.P.I.E.R. Engine
 {
-    PLUME
-    {
-        name = Turbojet
-        transformName = thrustTransform
-        localRotation = 0,0,0
-        localPosition = 0,0,-0.3
-        fixedScale = 0.7
-        energy = 0.8
-        speed = 1
-        emissionMult = 1.0
-    }
-    PLUME
-    {
-        name = Hypergolic-Lower
-        transformName = thrustTransform
-        localRotation = 0,0,0
-        plumePosition = 0,0,0.2
-        flarePosition = 0,0,0.4
-        plumeScale = 0.4
-        flareScale = 0.6
-        energy = 1
-        speed = 1
-        emissionMult = 1.0
-    }
-    @MODULE[ModuleEngines*],0
-    {
-        %powerEffectName = Turbojet
-        %spoolEffectName = Turbojet-Spool
-    }
-    @MODULE[ModuleEngines*],1
-    {
-        %powerEffectName = Hypergolic-Lower
-    }
+	PLUME
+	{
+		name = Methalox_AirBreathingMode
+		transformName = thrustTransform
+		localRotation = 0,0,0
+		localPosition = 0,0,0
+		fixedScale = 1
+		energy = 1
+		speed = 1
+		emissionMult = 0.7
+		alphaMult = 1
+		saturationMult = 1
+		flarePosition = 0,0,0.01
+		flareScale = 0.08
+		plumePosition = 0,0,0.1
+		plumeScale = 0.52
+		fumePosition = 0,0,0.4
+		fumeScale = 1.5
+		blazePosition = 0,0,3.9
+		blazeScale = 0.52
+		bypassTransformName = partTransform
+		bypassRotation = 90,0,0
+		bypassPosition = 0,-0.7,0
+		bypassScale = 1
+		smokePosition = 0,0,0.4
+		smokeScale = 0.7
+	}
+	PLUME
+	{
+		name = Methalox_LowerShock
+		transformName = thrustTransform
+		localRotation = 0,0,0
+		localPosition = 0,0,0
+		fixedScale = 1
+		energy = 1
+		speed = 1
+		emissionMult = 0.7
+		alphaMult = 1
+		saturationMult = 1
+		flarePosition = 0,0,0.01
+		flareScale = 0.08
+		plumePosition = 0,0,0.1
+		plumeScale = 0.52
+		fumePosition = 0,0,0.4
+		fumeScale = 1.5
+		blazePosition = 0,0,3.9
+		blazeScale = 0.52
+	}
+	@MODULE[ModuleEngines*],0
+	{
+		%powerEffectName = Methalox_AirBreathingMode
+		%spoolEffectName = Methalox_AirBreathingMode-Spool
+	}
+	@MODULE[ModuleEngines*],1
+	{
+		%powerEffectName = Methalox_LowerShock
+	}
+}
+//The stock model doesn't appear to have bypass ramjets
+@PART[RAPIER]:FOR[zzRealPlume]:NEEDS[!ReStock]
+{
+	@EFFECTS
+	{
+		@Methalox_AirBreathingMode
+		{
+			!MODEL_MULTI_SHURIKEN_PERSIST[bypass*],* {}
+		}
+	}
+}
+//The RAPIER has 4 smaller nozzles instead of one big nozzle, so just going by plumeScale makes it too quiet
+@PART[RAPIER]:FOR[zzRealPlume]:NEEDS[!ReStock]
+{
+	@EFFECTS
+	{
+		@Methalox_AirBreathingMode
+		{
+			@AUDIO
+			{
+				@volume,1[1, ] *= 4
+			}
+		}
+		@Methalox_LowerShock
+		{
+			@AUDIO
+			{
+				@volume,1[1, ] *= 4
+			}
+		}
+	}
 }


### PR DESCRIPTION
The ReStock RAPIER config makes use of the new "partTransform" support (see https://github.com/sarbian/SmokeScreen/pull/38 for details).  Until SmokeScreen officially updates, please use the attached build for this feature.

[SmokeScreen.zip](https://github.com/KSP-RO/RealPlume-StockConfigs/files/4467823/SmokeScreen.zip)
