### PR TITLE
Add ModuleManager depends to metanetkan

### DIFF
--- a/RealPlume-StockConfigs.netkan
+++ b/RealPlume-StockConfigs.netkan
@@ -1,10 +1,9 @@
 {
     "spec_version"      : "v1.4",
     "$kref"             : "#/ckan/github/KSP-RO/RealPlume-StockConfigs",
-    "ksp_version_min"   : "1.8.1",
-    "ksp_version_max"   : "1.9.99",
+    "$vref"             : "#/ckan/ksp-avc",
     "name"              : "Real Plume - Stock Configs",
-    "author"	          : [ "Zorg", "Nhawks1717", "Felger" ],
+    "author"            : [ "Zorg", "Nhawks1717", "Felger" ],
     "identifier"        : "RealPlume-StockConfigs",
     "abstract"          : "A set of configs for RealPlume to support stock and many mods with expanding Smokescreen plumes. Requires RealPlume and Smokescreen to function",
     "license"           : "CC-BY-NC-SA",
@@ -41,7 +40,7 @@
     ],
     "provides"  : [ "RealPlumeConfigs" ],
     "resources" : {
-    "homepage" : "https://forum.kerbalspaceprogram.com/index.php?/topic/188033-173-realplume-stock-v140-06sep19/"
+        "homepage" : "https://forum.kerbalspaceprogram.com/index.php?/topic/188033-173-realplume-stock-v140-06sep19/"
     },
     "install" : [
         {

--- a/RealPlume-StockConfigs.netkan
+++ b/RealPlume-StockConfigs.netkan
@@ -9,6 +9,7 @@
     "abstract"          : "A set of configs for RealPlume to support stock and many mods with expanding Smokescreen plumes. Requires RealPlume and Smokescreen to function",
     "license"           : "CC-BY-NC-SA",
     "depends" : [
+        { "name" : "ModuleManager" },
         { "name" : "RealPlume" }
     ],
     "suggests" : [


### PR DESCRIPTION
This mod uses a lot of ModuleManager syntax but its netkan doesn't have a MM dependency.
Now it does.

There's also a version file that isn't used.
Now it's used.