### PR TITLE
Fix missing config for revamped Reliant and Swivel

### DIFF
--- a/GameData/RealPlume-Stock/Squad/liquidEngine2_Swivel_v2.cfg
+++ b/GameData/RealPlume-Stock/Squad/liquidEngine2_Swivel_v2.cfg
@@ -1,0 +1,20 @@
+@PART[liquidEngine2_v2]:FOR[RealPlume]:NEEDS[SmokeScreen,!ReStock,!StockWaterfallEffects] // LV-T45 "Swivel" Liquid Fuel Engine
+{
+    PLUME
+    {
+        name = Kerolox-Upper
+        transformName = thrustTransform
+        localRotation = 0,0,0
+        flarePosition = 0,0,0.45
+        plumePosition = 0,0,0.6
+        plumeScale = 0.35
+        flareScale = 0.45
+        energy = 0.8
+        speed = 0.6
+    }
+    @MODULE[ModuleEngines*]
+    {
+        %powerEffectName = Kerolox-Upper
+		!runningEffectName = DELETE
+    }
+}

--- a/GameData/RealPlume-Stock/Squad/liquidEngine_Reliant_v2.cfg
+++ b/GameData/RealPlume-Stock/Squad/liquidEngine_Reliant_v2.cfg
@@ -1,0 +1,20 @@
+@PART[liquidEngine_v2]:FOR[RealPlume]:NEEDS[SmokeScreen,!ReStock,!StockWaterfallEffects] // LV-T30 "Reliant" Liquid Fuel Engine
+{
+    PLUME
+    {
+        name = Kerolox-Lower
+        transformName = thrustTransform
+        localRotation = 0,0,0
+        flarePosition = 0,0,0.5
+        plumePosition = 0,0,0.78
+        plumeScale = 0.25
+        flareScale = 0.6
+        energy = 1.0
+        speed = 0.6
+    }
+    @MODULE[ModuleEngines*]
+    {
+        %powerEffectName = Kerolox-Lower
+	    !runningEffectName = DELETE
+    }
+}


### PR DESCRIPTION
### Issues

[Reliant](https://wiki.kerbalspaceprogram.com/wiki/LV-T30_%22Reliant%22_Liquid_Fuel_Engine) and [Swivel](https://wiki.kerbalspaceprogram.com/wiki/LV-T45_%22Swivel%22_Liquid_Fuel_Engine) engines were revamped in version [1.12.2](https://wiki.kerbalspaceprogram.com/wiki/1.12.2#Parts).

This changed their part name from:
- `liquidEngine` to `liquidEngine_v2` (reliant)
- `liquidEngine2` to `liquidEngine2_v2` (swivel)

since realplume stock configs are loading `liquidEngine` and `liquidEngine2`, this makes realplume configs not load for revamped engines.

### Summary of changes

This commit adds two missing realplume configs for:
- [Reliant](https://wiki.kerbalspaceprogram.com/wiki/LV-T30_%22Reliant%22_Liquid_Fuel_Engine)
- [Swivel](https://wiki.kerbalspaceprogram.com/wiki/LV-T45_%22Swivel%22_Liquid_Fuel_Engine) 

Everything else is identical.

